### PR TITLE
Allow custom todo strings and set defaults

### DIFF
--- a/src/main/java/com/liveramp/pmd_extensions/WarnOnTodo.java
+++ b/src/main/java/com/liveramp/pmd_extensions/WarnOnTodo.java
@@ -5,18 +5,20 @@ import net.sourceforge.pmd.lang.java.ast.Comment;
 import net.sourceforge.pmd.lang.java.rule.comments.AbstractCommentRule;
 import net.sourceforge.pmd.lang.rule.properties.BooleanProperty;
 import net.sourceforge.pmd.lang.rule.properties.IntegerProperty;
+import net.sourceforge.pmd.lang.rule.properties.StringMultiProperty;
 
 /**
  * A rule that warns on TODOs
  */
 public class WarnOnTodo extends AbstractCommentRule {
-  public static final String TODO = "todo";
-  public static final IntegerProperty MAX_TODOS = new IntegerProperty("maxTodos", "Maximum number of Todos", 1, 100, 10, 2.0f);
-  public static final BooleanProperty REPORT_INDIVIDUALLY = new BooleanProperty("reportIndividually", "Set to true if each violation should be marked", false, 2.0f);
+  private static final IntegerProperty MAX_TODOS = new IntegerProperty("maxTodos", "Maximum number of Todos", 1, 100, 10, 2.0f);
+  private static final BooleanProperty REPORT_INDIVIDUALLY = new BooleanProperty("reportIndividually", "Set to true if each violation should be marked", false, 2.0f);
+  private static final StringMultiProperty TODO_STRINGS = new StringMultiProperty("todoStrings", "The strings that count as todos", new String[]{"todo", "fixme"}, 2.0f, '|');
 
   public WarnOnTodo() {
     definePropertyDescriptor(MAX_TODOS);
     definePropertyDescriptor(REPORT_INDIVIDUALLY);
+    definePropertyDescriptor(TODO_STRINGS);
   }
   
   @Override
@@ -24,12 +26,15 @@ public class WarnOnTodo extends AbstractCommentRule {
     int numTodos = 0;
     for (Comment comment : unit.getComments()) {
       String commentString = comment.getImage();
-      if (commentString.toLowerCase().contains(TODO)) {
-        if (getProperty(REPORT_INDIVIDUALLY)) {
-          addViolationWithMessage(data, unit, "Fix or remove TODO: " + commentString, comment.getBeginLine(), comment.getEndLine());
+      final String[] todoStrings = getProperty(TODO_STRINGS);
+      for (String todoString : todoStrings) {
+        if (commentString.toLowerCase().contains(todoString)) {
+          if (getProperty(REPORT_INDIVIDUALLY)) {
+            addViolationWithMessage(data, unit, "Fix or remove TODO: " + commentString, comment.getBeginLine(), comment.getEndLine());
+          }
+          numTodos++;
         }
-        numTodos++;
-      };
+      }
     }
 
     if (numTodos > getProperty(MAX_TODOS)) {


### PR DESCRIPTION
  Default strings considered to mark todos in comments are "todo" and "fixme"