### PR TITLE
Upgrade pmd_extensions to PMD 5.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,11 +50,6 @@
       <artifactId>guava</artifactId>
       <version>13.0.1</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.3.2</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd</artifactId>
-      <version>5.0.5</version>
+      <version>5.1.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistMethodHelper.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistMethodHelper.java
@@ -10,8 +10,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
+import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.lang.java.symboltable.NameOccurrence;
+import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 
 public class BlacklistMethodHelper {
 
@@ -22,7 +23,9 @@ public class BlacklistMethodHelper {
       if (PmdHelper.isSubclass(node, ruleClass)) {
         boolean isArray = node.isArray();
         for (NameOccurrence occ : node.getUsages()) {
-          NameOccurrence qualifier = occ.getNameForWhichThisIsAQualifier();
+          JavaNameOccurrence jocc = (JavaNameOccurrence) occ;
+          NameOccurrence qualifier = jocc.getNameForWhichThisIsAQualifier();
+          JavaNameOccurrence jqualifier = (JavaNameOccurrence) qualifier;
 
           if (qualifier != null) {
             String ruleMethodName = call.getRuleMethodName();
@@ -30,7 +33,7 @@ public class BlacklistMethodHelper {
             if (!isArray && qualifier.getImage().equals(ruleMethodName)) {
               Integer argumentCount = call.getArgumentCount();
 
-              if (argumentCount == null || argumentCount == qualifier.getArgumentCount()) {
+              if (argumentCount == null || argumentCount == jqualifier.getArgumentCount()) {
 
                 if(affectedClasses.isEmpty()){
                   markViolation(rule, data, occ.getLocation(), call);

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistMethodHelper.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistMethodHelper.java
@@ -57,7 +57,10 @@ public class BlacklistMethodHelper {
   }
 
   private static void markViolation(AbstractJavaRule rule, Object data, Node location, BlacklistedCall call) {
-    rule.addViolationWithMessage(data, location, "Suggested Alternative: " + call.getAlternativeMethod());
+    rule.addViolationWithMessage(
+        data,
+        location,
+        rule.getMessage() + " Suggested alternative: " + call.getAlternativeMethod());
   }
 
   public static void setContext(String methodProp, String classProp, RuleContext ctx, AbstractJavaRule rule) {

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistedStringLiterals.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistedStringLiterals.java
@@ -7,7 +7,6 @@ import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.rule.properties.StringProperty;
-import org.apache.commons.lang3.StringUtils;
 
 public class BlacklistedStringLiterals extends AbstractJavaRule {
   private static final String LIST_NAME = "BlacklistedStringLiterals.BlacklistedLiterals";
@@ -43,10 +42,13 @@ public class BlacklistedStringLiterals extends AbstractJavaRule {
     if(node.isStringLiteral()){
       String img = node.getImage();
 
-      for (String literal : getFromContext(data)) {
-        String imgStr = StringUtils.substring(img, 1, -1);
-        if(imgStr.equals(literal)){
-          addViolation(data, node);
+      if (img.length() > 2) {
+        String imgStr = img.substring(1, img.length() - 1);
+
+        for (String literal : getFromContext(data)) {
+          if(imgStr.equals(literal)){
+            addViolation(data, node);
+          }
         }
       }
     }

--- a/src/main/java/com/liveramp/pmd_extensions/SpecificUnusedLocalVariable.java
+++ b/src/main/java/com/liveramp/pmd_extensions/SpecificUnusedLocalVariable.java
@@ -9,8 +9,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.lang.java.symboltable.NameOccurrence;
+import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
 import net.sourceforge.pmd.lang.rule.properties.StringProperty;
+import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 
 /**
  * Mostly copied from UnusedLocalVariableRule
@@ -65,7 +66,8 @@ public class SpecificUnusedLocalVariable extends AbstractJavaRule {
 
   private boolean actuallyUsed(List<NameOccurrence> usages) {
     for (NameOccurrence occ : usages) {
-      if (occ.isOnLeftHandSide()) {
+      JavaNameOccurrence jocc = (JavaNameOccurrence) occ;
+      if (jocc.isOnLeftHandSide()) {
         continue;
       } else {
         return true;


### PR DESCRIPTION
We're using `pmd_extensions` from the Buck build system here at Facebook:

https://github.com/facebook/buck

I wanted to send in a few fixes I made:

1. Port to PMD 5.1.2 (new `JavaNameOccurrence` API)
2. Remove dependency on `apache-commons` `lang3` module (only used in one place)
3. Include original rule's message if an alternative API is specified in `BlacklistMethods`