### PR TITLE
catch at least simple versions of int/long casting bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.liveramp</groupId>
+      <artifactId>commons</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd</artifactId>
       <version>5.1.2</version>

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
@@ -1,7 +1,9 @@
 package com.liveramp.pmd_extensions;
 
 import java.util.Map;
+import java.util.Set;
 
+import com.google.common.collect.Sets;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
@@ -24,13 +26,15 @@ public class BlacklistLossyIncrementCast extends AbstractJavaRule {
       .put("byte", 8)
       .get();
 
+  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=");
+
   @Override
   public Object visit(ASTStatementExpression node, Object data) {
 
     if (node.jjtGetNumChildren() == 3) {
       Node assignment = node.jjtGetChild(1);
 
-      if (assignment.getImage().equals("+=")) {
+      if (LOSSY_ASSIGNMENTS.contains(assignment.getImage())) {
 
         String lhsType = getVariableType(node.jjtGetChild(0));
         String rhsType = getVariableType(node.jjtGetChild(2).jjtGetChild(0));

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
@@ -26,7 +26,7 @@ public class BlacklistLossyIncrementCast extends AbstractJavaRule {
       .put("byte", 8)
       .get();
 
-  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=");
+  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=", "*=");
 
   @Override
   public Object visit(ASTStatementExpression node, Object data) {

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
@@ -26,7 +26,7 @@ public class BlacklistLossyIncrementCast extends AbstractJavaRule {
       .put("byte", 8)
       .get();
 
-  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=", "*=");
+  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=", "*=", "^=");
 
   @Override
   public Object visit(ASTStatementExpression node, Object data) {

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
@@ -1,0 +1,87 @@
+package com.liveramp.pmd_extensions;
+
+import java.util.Map;
+
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
+import net.sourceforge.pmd.lang.symboltable.ScopedNode;
+
+import com.liveramp.commons.collections.map.MapBuilder;
+
+public class BlacklistLossyIncrementCast extends AbstractJavaRule {
+
+  private static final Map<String, Integer> TYPE_TO_BITS = new MapBuilder<String, Integer>()
+      .put("long", 64)
+      .put("int", 32)
+      .put("short", 16)
+      .put("byte", 8)
+      .get();
+
+  @Override
+  public Object visit(ASTStatementExpression node, Object data) {
+
+    if (node.jjtGetNumChildren() == 3) {
+      Node assignment = node.jjtGetChild(1);
+
+      if (assignment.getImage().equals("+=")) {
+
+        String lhsType = getVariableType(node.jjtGetChild(0));
+        String rhsType = getVariableType(node.jjtGetChild(2).jjtGetChild(0));
+
+        Integer lhsBits = TYPE_TO_BITS.get(lhsType);
+        Integer rhsBits = TYPE_TO_BITS.get(rhsType);
+
+        if (lhsBits != null && rhsBits != null) {
+          if (lhsBits < rhsBits) {
+            addViolation(data, node);
+          }
+        }
+      }
+
+    }
+
+    return super.visit(node, data);
+  }
+
+  private String getVariableType(Node lhs) {
+
+    Node prefix = lhs.jjtGetChild(0);
+    if (prefix instanceof ASTPrimaryPrefix) {
+      Node name = prefix.jjtGetChild(0);
+      if (name instanceof ASTName) {
+        ASTName nameNode = (ASTName)name;
+        NameDeclaration declaration = nameNode.getNameDeclaration();
+
+        if (declaration != null) {
+          ScopedNode declNode = declaration.getNode();
+
+          if (declNode instanceof ASTVariableDeclaratorId) {
+            ASTVariableDeclaratorId declarator = (ASTVariableDeclaratorId)declNode;
+            return declarator.getTypeNode().getTypeImage();
+          } else if (declNode instanceof ASTMethodDeclarator) {
+            ASTMethodDeclarator declarator = (ASTMethodDeclarator)declNode;
+            Node parent = declarator.jjtGetParent();
+
+            if (parent instanceof ASTMethodDeclaration) {
+              ASTMethodDeclaration methodParent = (ASTMethodDeclaration)parent;
+              //  ResultType.Type.X.image
+              return methodParent.getResultType().jjtGetChild(0).jjtGetChild(0).getImage();
+
+            }
+
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+}

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
@@ -26,7 +26,7 @@ public class BlacklistLossyIncrementCast extends AbstractJavaRule {
       .put("byte", 8)
       .get();
 
-  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=", "*=", "^=", "|=", "/=", "%=");
+  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=", "*=", "^=", "|=", "/=", "%=", "&=");
 
   @Override
   public Object visit(ASTStatementExpression node, Object data) {

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
@@ -26,7 +26,7 @@ public class BlacklistLossyIncrementCast extends AbstractJavaRule {
       .put("byte", 8)
       .get();
 
-  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=", "*=", "^=");
+  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=", "*=", "^=", "|=", "/=", "%=");
 
   @Override
   public Object visit(ASTStatementExpression node, Object data) {


### PR DESCRIPTION
This catches two simple versions of the int/long increment bug:

```
  public void myMethod(){
    int beefbeef = 0;
    beefbeef += someValue();
  }

  private long someValue(){
    return 5l;
  }

  public void myMethod2(){
    int beefbeef = 0;
    long incincincinc = 0;
    beefbeef += incincincinc;
  }
```

Let me know if you think of any other common variants on this mistake.

@roshan 
@michel-tricot  
