### PR TITLE
Remove Guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,6 @@
       <version>5.1.2</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>13.0.1</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.liveramp</groupId>
-      <artifactId>commons</artifactId>
-      <version>1.1-SNAPSHOT</version>
-    </dependency>
-    <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd</artifactId>
       <version>5.1.2</version>

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistCallChain.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistCallChain.java
@@ -1,11 +1,11 @@
 package com.liveramp.pmd_extensions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
@@ -28,7 +28,7 @@ public class BlacklistCallChain extends AbstractJavaRule {
 
   @Override
   public void start(RuleContext ctx) {
-    Set<List<String>> chains = Sets.newHashSet();
+    Set<List<String>> chains = new HashSet<>();
     Object prop = getProperty(getPropertyDescriptor(CALL_CHAIN));
     for (String reference : prop.toString().split(",")) {
       chains.add(Arrays.asList(reference.trim().split("\\.")));
@@ -49,7 +49,7 @@ public class BlacklistCallChain extends AbstractJavaRule {
     Set<List<String>> badCalls = getCallsFromContext(data);
     List<String> affectedClasses = BlacklistMethodHelper.getClassesFromContext(data, CLASS_LIST);
 
-    List<String> parts = Lists.newArrayList();
+    List<String> parts = new ArrayList<>();
     for (int i = 0; i < node.jjtGetNumChildren(); i++) {
       List<String> image = image(node.jjtGetChild(i));
       if(!image.isEmpty()){
@@ -72,7 +72,7 @@ public class BlacklistCallChain extends AbstractJavaRule {
     if(node instanceof ASTPrimaryPrefix){
       ASTPrimaryPrefix prefix = (ASTPrimaryPrefix) node;
 
-      List<String> results = Lists.newArrayList();
+      List<String> results = new ArrayList<>();
       for (int i = 0; i < prefix.jjtGetNumChildren(); i++) {
         results.addAll(image(prefix.jjtGetChild(i)));
       }
@@ -80,14 +80,14 @@ public class BlacklistCallChain extends AbstractJavaRule {
 
     }else if(node instanceof ASTPrimarySuffix){
       if(node.getImage() != null) {
-        return Lists.newArrayList(node.getImage().split("\\."));
+        return Arrays.asList(node.getImage().split("\\."));
       }
     }else if(node instanceof ASTName){
       if(node.getImage() != null) {
-        return Lists.newArrayList(node.getImage().split("\\."));
+        return Arrays.asList(node.getImage().split("\\."));
       }
     }
-    return Lists.newArrayList();
+    return new ArrayList<>();
   }
 
 }

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
@@ -1,9 +1,11 @@
 package com.liveramp.pmd_extensions;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
@@ -26,7 +28,7 @@ public class BlacklistLossyIncrementCast extends AbstractJavaRule {
       .put("byte", 8)
       .get();
 
-  private static final Set<String> LOSSY_ASSIGNMENTS = Sets.newHashSet("+=", "-=", "*=", "^=", "|=", "/=", "%=", "&=");
+  private static final Set<String> LOSSY_ASSIGNMENTS = new HashSet<>(Arrays.asList("+=", "-=", "*=", "^=", "|=", "/=", "%=", "&="));
 
   @Override
   public Object visit(ASTStatementExpression node, Object data) {

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistLossyIncrementCast.java
@@ -17,16 +17,16 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.ScopedNode;
 
-import com.liveramp.commons.collections.map.MapBuilder;
-
 public class BlacklistLossyIncrementCast extends AbstractJavaRule {
 
-  private static final Map<String, Integer> TYPE_TO_BITS = new MapBuilder<String, Integer>()
-      .put("long", 64)
-      .put("int", 32)
-      .put("short", 16)
-      .put("byte", 8)
-      .get();
+  private static final Map<String, Integer> TYPE_TO_BITS = new HashMap<>();
+
+  static {
+    TYPE_TO_BITS.put("long", 64);
+    TYPE_TO_BITS.put("int", 32);
+    TYPE_TO_BITS.put("short", 16);
+    TYPE_TO_BITS.put("byte", 8);
+  }
 
   private static final Set<String> LOSSY_ASSIGNMENTS = new HashSet<>(Arrays.asList("+=", "-=", "*=", "^=", "|=", "/=", "%=", "&="));
 

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistMethodHelper.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistMethodHelper.java
@@ -1,9 +1,9 @@
 package com.liveramp.pmd_extensions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
@@ -66,7 +66,7 @@ public class BlacklistMethodHelper {
   public static void setContext(String methodProp, String classProp, RuleContext ctx, AbstractJavaRule rule) {
 
     if(methodProp != null) {
-      List<BlacklistedCall> blockedCalls = Lists.newArrayList();
+      List<BlacklistedCall> blockedCalls = new ArrayList<>();
       Object prop = rule.getProperty(rule.getPropertyDescriptor(methodProp));
       for (String reference : prop.toString().split(",")) {
         blockedCalls.add(parseRef(reference.trim()));
@@ -75,7 +75,7 @@ public class BlacklistMethodHelper {
     }
 
     if(classProp != null) {
-      List<String> blacklistedClasses = Lists.newArrayList();
+      List<String> blacklistedClasses = new ArrayList<>();
       Object classes = rule.getProperty(rule.getPropertyDescriptor(classProp));
       if (classes != null) {
         for (String className : classes.toString().split(",")) {

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistedStringLiterals.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistedStringLiterals.java
@@ -1,8 +1,8 @@
 package com.liveramp.pmd_extensions;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
@@ -17,7 +17,7 @@ public class BlacklistedStringLiterals extends AbstractJavaRule {
 
   @Override
   public void start(RuleContext ctx) {
-    List<String> blacklistedClasses = Lists.newArrayList();
+    List<String> blacklistedClasses = new ArrayList<>();
     Object prop = getProperty(getPropertyDescriptor(LIST_NAME));
     for (String className : prop.toString().split(",")) {
       blacklistedClasses.add(className.trim());

--- a/src/main/java/com/liveramp/pmd_extensions/NoLoggingInClasses.java
+++ b/src/main/java/com/liveramp/pmd_extensions/NoLoggingInClasses.java
@@ -1,9 +1,10 @@
 package com.liveramp.pmd_extensions;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
@@ -18,12 +19,12 @@ public class NoLoggingInClasses extends AbstractJavaRule {
   private static final String LIST_NAME = "NoLoggingInClasses.BlacklistedMethods";
   private static final String CLASS_LIST = "NoLoggingInClasses.ClassesToInspect";
 
-  private static final Set<String> LOG_IMAGES = Sets.newHashSet(
+  private static final Set<String> LOG_IMAGES = new HashSet<>(Arrays.asList(
       "System.out.println",
       "System.out.print",
       "System.err.println",
       "System.err.print"
-  );
+  ));
 
   public NoLoggingInClasses(){
     definePropertyDescriptor(new StringProperty(LIST_NAME, "List of methods to blacklist", "", 0));

--- a/src/main/java/com/liveramp/pmd_extensions/PmdHelper.java
+++ b/src/main/java/com/liveramp/pmd_extensions/PmdHelper.java
@@ -1,12 +1,12 @@
 package com.liveramp.pmd_extensions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
@@ -35,18 +35,16 @@ public class PmdHelper {
       return true;
     }
 
-    Collection<String> implementors = Collections2.transform(Arrays.asList(type.getInterfaces()), new Function<Class, String>() {
-      @Override
-      public String apply(Class aClass) {
-        return aClass.getName();
-      }
-    });
+    Collection<String> implementors = Stream.of(type.getInterfaces())
+        .map(Class::getName)
+        .collect(Collectors.toList());
 
     if (implementors.contains(clazz)) {
       return true;
     }
 
-    List<Class<?>> supers = Lists.<Class<?>>newArrayList(type.getSuperclass());
+    List<Class<?>> supers = new ArrayList<>();
+    supers.add(type.getSuperclass());
     supers.addAll(Arrays.<Class<?>>asList(type.getInterfaces()));
 
     for (Class<?> superC : supers) {

--- a/src/main/java/com/liveramp/pmd_extensions/SpecificUnusedLocalVariable.java
+++ b/src/main/java/com/liveramp/pmd_extensions/SpecificUnusedLocalVariable.java
@@ -1,9 +1,9 @@
 package com.liveramp.pmd_extensions;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
@@ -26,7 +26,7 @@ public class SpecificUnusedLocalVariable extends AbstractJavaRule {
 
   @Override
   public void start(RuleContext ctx) {
-    Set<String> classes = Sets.newHashSet();
+    Set<String> classes = new HashSet<>();
     Object prop = getProperty(getPropertyDescriptor(CLASS_LIST));
     for (String reference : prop.toString().split(",")) {
       classes.add(reference.trim());


### PR DESCRIPTION
If you include `pmd_extensions` in your build tools it's far too easy to
get stuck on the version of Guava used. Guava isn't actually used in the
project, though.