### PR TITLE
Fix BlacklistMethods to handle multiple rules

### DIFF
--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistMethodHelper.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistMethodHelper.java
@@ -1,7 +1,6 @@
 package com.liveramp.pmd_extensions;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import net.sourceforge.pmd.RuleContext;
@@ -69,7 +68,7 @@ public class BlacklistMethodHelper {
       List<BlacklistedCall> blockedCalls = new ArrayList<>();
       Object prop = rule.getProperty(rule.getPropertyDescriptor(methodProp));
       for (String reference : prop.toString().split(",")) {
-        blockedCalls.add(parseRef(reference.trim()));
+        blockedCalls.add(BlacklistedCallFactory.from(reference.trim()));
       }
       ctx.setAttribute(methodProp, blockedCalls);
     }
@@ -85,23 +84,6 @@ public class BlacklistMethodHelper {
       ctx.setAttribute(classProp, blacklistedClasses);
     }
 
-  }
-
-  private static BlacklistedCall parseRef(String s){
-    String[] origAlt = s.split(";");
-
-    if (origAlt.length != 2) {
-      throw new RuntimeException("Blacklisting " + s + ": Must supply alternative");
-    }
-
-    String[] parts = origAlt[0].split(":");
-    if (parts.length == 2){
-      return new BlacklistedCall(parts[0], parts[1], origAlt[1]);
-    }
-    if (parts.length == 3){
-      return new BlacklistedCall(parts[0], parts[1], Integer.parseInt(parts[2]), origAlt[1]);
-    }
-    throw new RuntimeException("Cannot parse method reference: "+ origAlt[0] +". Parts: " + Arrays.toString(parts));
   }
 
   public static boolean checkStaticMethods(ASTPrimaryPrefix node, Object data, List<BlacklistedCall> blockedCalls, List<String> affectedClasses, AbstractJavaRule rule) {

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistMethods.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistMethods.java
@@ -1,13 +1,14 @@
 package com.liveramp.pmd_extensions;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.lang.rule.properties.StringProperty;
+import net.sourceforge.pmd.lang.rule.properties.StringMultiProperty;
 
 /**
  * Fail any build which uses certain methods on particular classes.  Example configuration in rule set:
@@ -21,23 +22,27 @@ import net.sourceforge.pmd.lang.rule.properties.StringProperty;
  *   is banned
  */
 public class BlacklistMethods extends AbstractJavaRule {
-  private static final String LIST_NAME = "BlacklistMethods.BlacklistedMethods";
+  private static final PropertyDescriptor<String[]> METHODS_LIST_DESCRIPTOR =
+      new WhitespaceStrippingStringDescriptor(
+          new StringMultiProperty(
+              "BlacklistMethods.BlacklistedMethods",
+              "List of methods to blacklist",
+              new String[]{},
+              0,
+              ','));
+
+  private final BlacklistedCallFactory blacklistedCallFactory = new BlacklistedCallFactory();
 
   public BlacklistMethods() {
-    definePropertyDescriptor(new StringProperty(LIST_NAME, "List of methods to blacklist", "", 0));
-  }
-
-
-  @Override
-  public void start(RuleContext ctx) {
-    BlacklistMethodHelper.setContext(LIST_NAME, null, ctx, this);
-    super.start(ctx);
+    definePropertyDescriptor(METHODS_LIST_DESCRIPTOR);
   }
 
   @Override
   public Object visit(ASTVariableDeclaratorId node, Object data) {
-    BlacklistMethodHelper.checkForMethods(node, data,
-        BlacklistMethodHelper.getCallsFromContext(data, LIST_NAME),
+    BlacklistMethodHelper.checkForMethods(
+        node,
+        data,
+        getBlacklistedCalls(),
         Collections.<String>emptyList(),
         this
     );
@@ -49,13 +54,24 @@ public class BlacklistMethods extends AbstractJavaRule {
    */
   @Override
   public Object visit(ASTPrimaryPrefix node, Object data) {
-    List<BlacklistedCall> blockedCalls = BlacklistMethodHelper.getCallsFromContext(data, LIST_NAME);
-
-    if (BlacklistMethodHelper.checkStaticMethods(node, data, blockedCalls, Collections.<String>emptyList(), this)) {
+    if (BlacklistMethodHelper.checkStaticMethods(
+        node,
+        data,
+        getBlacklistedCalls(),
+        Collections.<String>emptyList(),
+        this)) {
       return super.visit(node, data);
     }
 
     return super.visit(node, data);
+  }
+
+  private List<BlacklistedCall> getBlacklistedCalls() {
+    List<BlacklistedCall> blacklistedCalls = new ArrayList<>();
+    for (String blackListedCallsDeclaration : getProperty(METHODS_LIST_DESCRIPTOR)) {
+      blacklistedCalls.add(blacklistedCallFactory.getBlacklistedCall(blackListedCallsDeclaration));
+    }
+    return blacklistedCalls;
   }
 
 }

--- a/src/main/java/com/liveramp/pmd_extensions/BlacklistedCallFactory.java
+++ b/src/main/java/com/liveramp/pmd_extensions/BlacklistedCallFactory.java
@@ -1,0 +1,40 @@
+package com.liveramp.pmd_extensions;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This factory keeps a mapping of call declaration to constructed {@link BlacklistedCall} objects to avoid
+ * re-parsing declarations.
+ */
+public class BlacklistedCallFactory {
+
+  private final Map<String, BlacklistedCall> blacklistedCalls = new HashMap<>();
+
+  public synchronized BlacklistedCall getBlacklistedCall(String callDeclaration) {
+    if (blacklistedCalls.containsKey(callDeclaration)) {
+      return blacklistedCalls.get(callDeclaration);
+    }
+    BlacklistedCall blacklistedCall = from(callDeclaration);
+    blacklistedCalls.put(callDeclaration, blacklistedCall);
+    return blacklistedCall;
+  }
+
+  public static BlacklistedCall from(String s) {
+    String[] origAlt = s.split(";");
+
+    if (origAlt.length != 2) {
+      throw new RuntimeException("Blacklisting " + s + ": Must supply alternative");
+    }
+
+    String[] parts = origAlt[0].split(":");
+    if (parts.length == 2){
+      return new BlacklistedCall(parts[0], parts[1], origAlt[1]);
+    }
+    if (parts.length == 3){
+      return new BlacklistedCall(parts[0], parts[1], Integer.parseInt(parts[2]), origAlt[1]);
+    }
+    throw new RuntimeException("Cannot parse method reference: "+ origAlt[0] +". Parts: " + Arrays.toString(parts));
+  }
+}


### PR DESCRIPTION
Fixes a problem similar to `BlacklistClassUsages` (see f91a3df3b5da27e60f73e80dadf43e3183bd0144).

`RuleContext` is shared between rules and when there are multiple rules, only one declaration is used.
