### PR TITLE
Fix detecting static method references in BlacklistMethods

### DIFF
--- a/src/main/java/com/liveramp/pmd_extensions/PmdHelper.java
+++ b/src/main/java/com/liveramp/pmd_extensions/PmdHelper.java
@@ -23,12 +23,18 @@ public class PmdHelper {
     return parts[parts.length - 1];
   }
 
+  private static String getClassFromStaticMethodReference(String image) {
+    return image.split("\\.")[0];
+  }
+
   public static boolean isSubclass(TypeNode n, String clazz) {
 
     Class type = n.getType();
+
     if (type == null) {
       String image = ((Node)n).getImage();
-      return simpleName(clazz).equals(image) || clazz.equals(image);
+      return simpleName(clazz).equals(image) || clazz.equals(image)
+          || simpleName(clazz).equals(getClassFromStaticMethodReference(image));
     }
 
     if (type.getName().equals(clazz)) {


### PR DESCRIPTION
Static methods are represented with `image` in the form of "System.getenv" and no type information. 